### PR TITLE
Add server test and npm script

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "leaflet-public-map-tester",
+  "version": "1.0.0",
+  "scripts": {
+    "test": "node tests/server.test.js"
+  }
+}

--- a/server.js
+++ b/server.js
@@ -18,11 +18,14 @@ const MIME_TYPES = {
 
 const server = http.createServer((req, res) => {
   console.log(`Request: ${req.url}`);
-  
+
+  // Strip query string from the URL to find the actual file path
+  const pathname = req.url.split('?')[0];
+
   // Handle root path
-  let filePath = req.url === '/' 
+  let filePath = pathname === '/'
     ? path.join(__dirname, 'index.html')
-    : path.join(__dirname, req.url);
+    : path.join(__dirname, pathname);
   
   const extname = path.extname(filePath);
   let contentType = MIME_TYPES[extname] || 'application/octet-stream';
@@ -46,6 +49,10 @@ const server = http.createServer((req, res) => {
   });
 });
 
-server.listen(PORT, () => {
-  console.log(`Server running at http://localhost:${PORT}/`);
-});
+if (require.main === module) {
+  server.listen(PORT, () => {
+    console.log(`Server running at http://localhost:${PORT}/`);
+  });
+}
+
+module.exports = server;

--- a/tests/server.test.js
+++ b/tests/server.test.js
@@ -1,0 +1,34 @@
+const http = require('http');
+const assert = require('assert');
+const server = require('../server');
+
+function request(port, path) {
+  return new Promise((resolve, reject) => {
+    const req = http.get({ port, path }, (res) => {
+      res.resume();
+      res.on('end', () => resolve(res));
+    });
+    req.on('error', reject);
+  });
+}
+
+(async () => {
+  await new Promise((resolve) => server.listen(0, resolve));
+  const port = server.address().port;
+
+  try {
+    const res1 = await request(port, '/index.html?foo=bar');
+    assert.strictEqual(res1.statusCode, 200, 'index.html should return 200');
+
+    const res2 = await request(port, '/does-not-exist.txt');
+    assert.strictEqual(res2.statusCode, 404, 'nonexistent file should return 404');
+
+    console.log('All tests passed');
+  } catch (err) {
+    console.error('Test failed');
+    console.error(err);
+    process.exitCode = 1;
+  } finally {
+    server.close();
+  }
+})();


### PR DESCRIPTION
## Summary
- export server instance without auto-starting
- strip query strings when reading files
- add simple server tests
- provide npm `test` script

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_685060fd6d408331ac6d1b65c3a9c5a0