### PR TITLE
Add support for loading local GeoJSON files

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ A simple web application that demonstrates the use of Leaflet.js with OpenStreet
 - Uses OpenStreetMap tiles via the URL: `https://tile.openstreetmap.org/{z}/{x}/{y}.png`
 - Includes a sample marker with popup
 - Includes a scale control
+- Load additional map layers via URL or local GeoJSON file
 
 ## How to Run
 

--- a/app.js
+++ b/app.js
@@ -103,6 +103,31 @@ function createGeoJSONLayer(url) {
   });
 }
 
+// Function to create a GeoJSON layer from already loaded data
+function createGeoJSONLayerFromData(data) {
+  return L.geoJSON(data, {
+    style: function(feature) {
+      return {
+        color: '#c75b1c',
+        weight: 2,
+        opacity: 1,
+        fillColor: '#c75b1c',
+        fillOpacity: 0.5
+      };
+    },
+    pointToLayer: function(feature, latlng) {
+      return L.circleMarker(latlng, {
+        radius: 6,
+        fillColor: '#c75b1c',
+        color: '#c75b1c',
+        weight: 1,
+        opacity: 1,
+        fillOpacity: 0.5
+      });
+    }
+  });
+}
+
 // Function to create a Vector Grid layer
 function createVectorGridLayer(url) {
   return L.vectorGrid.protobuf(url, {
@@ -281,6 +306,45 @@ document.getElementById('add-map-btn').addEventListener('click', async function(
   } catch (error) {
     console.error('Error creating layer:', error);
     alert(`Error creating layer: ${error.message}`);
+  }
+});
+
+// Handle adding a GeoJSON layer from a local file
+document.getElementById('add-file-btn').addEventListener('click', async function() {
+  const fileInput = document.getElementById('file-input');
+  const file = fileInput.files[0];
+
+  if (!file) {
+    alert('Please select a GeoJSON file');
+    return;
+  }
+
+  try {
+    const text = await file.text();
+    const data = JSON.parse(text);
+
+    const layerId = generateLayerId();
+    const displayName = file.name;
+    const layer = createGeoJSONLayerFromData(data);
+
+    layer.addTo(map);
+
+    customLayers.push({
+      id: layerId,
+      type: 'GEOJSON',
+      url: file.name,
+      name: displayName,
+      layer: layer
+    });
+
+    addLayerToList(layerId, displayName, 'GEOJSON', layer);
+
+    console.log(`GEOJSON layer (${layerId}) added from file`);
+
+    fileInput.value = '';
+  } catch (error) {
+    console.error('Error reading GeoJSON file:', error);
+    alert(`Error reading GeoJSON file: ${error.message}`);
   }
 });
 

--- a/index.html
+++ b/index.html
@@ -124,12 +124,14 @@ href="https://unpkg.com/leaflet@1.7.1/dist/leaflet.css"
 <body>
   <div class="controls">
     <input type="text" id="url-input" placeholder="Enter URL..." />
+    <input type="file" id="file-input" accept=".geojson,.json" />
     <select id="maptype-select">
       <option value="TILE">TILE</option>
       <option value="GEOJSON">GEOJSON</option>
       <option value="VECTORGRID">VECTORGRID</option>
     </select>
     <button id="add-map-btn">ADD MAP</button>
+    <button id="add-file-btn">ADD GEOJSON FILE</button>
   </div>
   <div class="layer-list-container">
     <div class="layer-list">


### PR DESCRIPTION
## Summary
- allow selecting a local GeoJSON file and add it to the map
- style loaded files like regular GeoJSON layers
- document ability to load layers from a file

## Testing
- `node -c app.js`

------
https://chatgpt.com/codex/tasks/task_b_6855cfc963d88331be05455c5deba498